### PR TITLE
ci: add sonarcloud

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -31,11 +31,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           version: ${{env.GO_VERSION}}
       - name: Run Tests
         run: go test -cover ./...
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.organization=crazybolillo
+            -Dsonar.projectKey=crazybolillo_alertapp
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit adds  sonarcloud to the CI pipeline.

https://sonarcloud.io/project/overview?id=crazybolillo_alertapp