### PR TITLE
ci: store built binary as artifact

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -58,6 +58,10 @@ jobs:
           version: ${{env.GO_VERSION}}
       - name: Build
         run: go build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binary
+          path: alertapp
       - uses: zoftko/elfwatch-action@main
         with:
           file: alertapp


### PR DESCRIPTION
This is to allow local analysis as the built binary will now be available for download.