### PR TITLE
ci: store artifact, pin elf-watch to v1

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -58,7 +58,11 @@ jobs:
           version: ${{env.GO_VERSION}}
       - name: Build
         run: go build
-      - uses: zoftko/elfwatch-action@main
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binary
+          path: alertapp
+      - uses: zoftko/elfwatch-action@v1
         with:
           file: alertapp
           token: ${{ secrets.ELF_WATCH_TOKEN }}


### PR DESCRIPTION
Storing the artifact should make it easier to debug elfwatch if any issues arise. Also pinned it to v1 since that's the proper way to use it.